### PR TITLE
fix: 修复多个eventName时报错

### DIFF
--- a/jQuery-hook.js
+++ b/jQuery-hook.js
@@ -245,13 +245,15 @@
      * @param eventFunction
      */
     function setEventFunctionNameToDomObjectAttribute(domObject, eventName, eventFunction) {
-        const {formatEventName, eventFuncGlobalName} = storeToWindow(eventName, eventFunction);
-        const attrName = `${globalUniqPrefix}-jQuery-${formatEventName}-event-function`;
-        if (domObject.attr(attrName)) {
-            domObject.attr(attrName + "-" + new Date().getTime(), eventFuncGlobalName);
-        } else {
-            domObject.attr(attrName, eventFuncGlobalName);
-        }
+        eventName.split(' ').map((eventName) => {
+            const {formatEventName, eventFuncGlobalName} = storeToWindow(eventName, eventFunction);
+            const attrName = `${globalUniqPrefix}-jQuery-${formatEventName}-event-function`;
+            if (domObject.attr(attrName)) {
+                domObject.attr(attrName + "-" + new Date().getTime(), eventFuncGlobalName);
+            } else {
+                domObject.attr(attrName, eventFuncGlobalName);
+            }
+        })
     }
 
     // ----------------------------------------------- -----------------------------------------------------------------


### PR DESCRIPTION
如果传入的eventName为多个事件（事件以空格隔开），会导致hook报错。
<img width="1404" alt="image" src="https://github.com/JSREI/jQuery-hook/assets/17334895/c4f74d45-be7e-4523-a305-756dd36b662e">
<img width="1427" alt="image" src="https://github.com/JSREI/jQuery-hook/assets/17334895/da63c472-aa00-4a54-8552-79c151066c77">
